### PR TITLE
Rename DOCKER_CONTAINER_IMAGE => DOCKER_NOTEBOOK_IMAGE

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ DOCKER_MACHINE_NAME=jupyterhub
 DOCKER_NETWORK_NAME=jupyterhub-network
 
 # Single-user Jupyter Notebook server container image
-DOCKER_CONTAINER_IMAGE=jupyter/scipy-notebook:2d878db5cbff
+DOCKER_NOTEBOOK_IMAGE=jupyter/scipy-notebook:2d878db5cbff
 
 # Docker run command to use when spawning single-user containers
 DOCKER_SPAWN_CMD=start-singleuser.sh

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Notebook servers. You set the desired Notebook server image in a
 `DOCKER_NOTEBOOK_IMAGE` environment variable.
 
 JupyterHub reads the Notebook image name from `jupyterhub_config.py`, which
-reads the Notebook image name from the `DOCKER_CONTAINER_IMAGE` environment
+reads the Notebook image name from the `DOCKER_NOTEBOOK_IMAGE` environment
 variable:
 
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ export DRIVER_OPTS="--driver softlayer \
   --softlayer-memory 65536 \
   --softlayer-disk-size 100 \
   --softlayer-region wdc01"
-  
+
 # Create a machine named jupyterhub
 docker-machine create $DRIVER_OPTS jupyterhub
 
@@ -178,9 +178,9 @@ docker pull jupyter/scipy-notebook:2d878db5cbff
 ```
 
 Note: If you choose to use a container image other than
-``jupyter/scipy-notebook``, you must change the `DOCKER_CONTAINER_IMAGE` value 
+``jupyter/scipy-notebook``, you must change the `DOCKER_NOTEBOOK_IMAGE` value
 of the `.env` file to the desired container image. Alternatively, you can
-override the value by setting the `DOCKER_CONTAINER_IMAGE` variable to a
+override the value by setting the `DOCKER_NOTEBOOK_IMAGE` variable to a
 different Notebook image in the environment where you launch JupyterHub.
 
 ## Run the JupyterHub container
@@ -215,38 +215,37 @@ Use `docker logs <container>`.  For example, to view the logs of the `jupyterhub
 docker logs jupyterhub
 ```
 
-### How do I specify the Notebook server image to spawn for users? 
+### How do I specify the Notebook server image to spawn for users?
 
 In this deployment, JupyterHub uses DockerSpawner to spawn single-user
 Notebook servers. You set the desired Notebook server image in a
-`DOCKER_CONTAINER_IMAGE` environment variable.
+`DOCKER_NOTEBOOK_IMAGE` environment variable.
 
-When spawning single-user notebooks, JupyterHub reads the DockerSpawner's 
-image name from `jupyterhub_config.py` file. This file includes the
-DockerSpawner's image name which refers to desired image in the
-`DOCKER_CONTAINER_IMAGE` environment variable:
+JupyterHub reads the Notebook image name from `jupyterhub_config.py`, which
+reads the Notebook image name from the `DOCKER_CONTAINER_IMAGE` environment
+variable:
 
 ```
 # DockerSpawner setting in jupyterhub_config.py
-c.DockerSpawner.container_image = os.environ['DOCKER_CONTAINER_IMAGE']
+c.DockerSpawner.container_image = os.environ['DOCKER_NOTEBOOK_IMAGE']
 ```
 
-By default, the`DOCKER_CONTAINER_IMAGE` environment variable is set in the
+By default, the`DOCKER_NOTEBOOK_IMAGE` environment variable is set in the
 `.env` file.
 
 ```
 # Setting in the .env file
-DOCKER_CONTAINER_IMAGE=jupyter/scipy-notebook:2d878db5cbff
+DOCKER_NOTEBOOK_IMAGE=jupyter/scipy-notebook:2d878db5cbff
 ```
 
 To use a different notebook server image, you can either change the desired
 container image value in the `.env` file, or you can override it
-by setting the `DOCKER_CONTAINER_IMAGE` variable to a different Notebook
+by setting the `DOCKER_NOTEBOOK_IMAGE` variable to a different Notebook
 image in the environment where you launch JupyterHub. For example, the
-following setting would be used to spawn single-user pyspark notebook servers:
+following setting would be used to spawn single-user `pyspark` notebook servers:
 
 ```
-DOCKER_CONTAINER_IMAGE=jupyterhub/pyspark-notebook:2d878db5cbff \ 
+DOCKER_NOTEBOOK_IMAGE=jupyterhub/pyspark-notebook:2d878db5cbff \
 	./hub.sh up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
       DOCKER_TLS_KEY: "/etc/docker/server-key.pem"
       # All containers will join this network
       DOCKER_NETWORK_NAME: ${DOCKER_NETWORK_NAME}
-      # JupyterHub will spawn this image for users
-      DOCKER_CONTAINER_IMAGE: ${DOCKER_CONTAINER_IMAGE}
+      # JupyterHub will spawn this Notebook image for users
+      DOCKER_NOTEBOOK_IMAGE: ${DOCKER_NOTEBOOK_IMAGE}
       # Using this run command (optional)
       DOCKER_SPAWN_CMD: ${DOCKER_SPAWN_CMD}
       # Required to authenticate users using GitHub OAuth

--- a/examples/custom-notebook-server/README.md
+++ b/examples/custom-notebook-server/README.md
@@ -15,10 +15,13 @@ docker build -t my-custom-notebook .
 
 ## Run JupyterHub Container
 
-To have JupyterHub spawn the `my-custom-notebook` image for single-user Notebook servers, set the `DOCKER_CONTAINER_IMAGE` environment variable to the image name when you run the JupyterHub container.  For example, run the following **from the root directory** of this repository:
+To have JupyterHub spawn the `my-custom-notebook` image for single-user Notebook
+servers, set the `DOCKER_NOTEBOOK_IMAGE` environment variable to the image name
+when you run the JupyterHub container.  For example, run the following
+**from the root directory** of this repository:
 
 ```
-export DOCKER_CONTAINER_IMAGE=my-custom-notebook
+export DOCKER_NOTEBOOK_IMAGE=my-custom-notebook
 
 # bring down the JupyterHub container, if running
 ./hub.sh down

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -13,7 +13,7 @@ c = get_config()
 # Spawn single-user servers as Docker containers
 c.JupyterHub.spawner_class = 'dockerspawner.DockerSpawner'
 # Spawn containers from this image
-c.DockerSpawner.container_image = os.environ['DOCKER_CONTAINER_IMAGE']
+c.DockerSpawner.container_image = os.environ['DOCKER_NOTEBOOK_IMAGE']
 # JupyterHub requires a single-user instance of the Notebook server, so we
 # default to using the `start-singleuser.sh` script included in the
 # jupyter/docker-stacks *-notebook images as the Docker run command when


### PR DESCRIPTION
Renamed the environment variable used to specify the image from which to spawn Notebook server containers.