### PR TITLE
Peg versions of JupyterHub base image and dependencies

### DIFF
--- a/Dockerfile.jupyterhub
+++ b/Dockerfile.jupyterhub
@@ -1,12 +1,12 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyter/jupyterhub:master
+FROM jupyterhub/jupyterhub-onbuild:0.6.1
 
 # Install dockerspawner and its dependencies
 RUN /opt/conda/bin/pip install \
-    -e git+https://github.com/jupyter/jupyterhub@62a5e9dbce86cbb8992def81600ff9881d515935#egg=jupyterhub \
-    -e git+https://github.com/jupyter/oauthenticator@011f6ea25c6bafca087d94a6c73d24dcbb0bf80e#egg=oauthenticator \
-    -e git+https://github.com/jupyter/dockerspawner@3c5e36bc96a252a04bb7700fdb009bd572996f3a#egg=dockerspawner
+    jupyterhub==0.6.* \
+    oauthenticator==0.3.* \
+    dockerspawner==0.3.*
 
 # Copy TLS certificate and key
 ENV SSL_CERT /srv/jupyterhub/secrets/jupyterhub.cer

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ OAUTH_CALLBACK_URL=https://<myhost.mydomain>/hub/oauth_callback
 
 Configure JupyterHub and build it into a Docker image.
 
-1. Copy your TLS certificate and key to a directory named `secrets` within this repository directory.  These will be added to the Docker image at build time.
+1. Copy the TLS certificate chain and key files for the JupyterHub server to a directory named `secrets` within this repository directory.  These will be added to the JupyterHub Docker image at build time.  If you do not have a certificate chain and key, you can either [create self-signed versions](https://jupyter-notebook.readthedocs.org/en/latest/public_server.html#using-ssl-for-encrypted-communication), or obtain real ones from [Let's Encrypt](https://letsencrypt.org) (see the [letsencrypt example](examples/letsencrypt/README.md) for instructions).
 
     ```
     mkdir -p secrets


### PR DESCRIPTION
* Peg the JHub base Docker image to `jupyterhub/jupyterhub-onbuild:0.6.1`.
* `pip install` the latest releases of the JHub dependencies.