### PR TITLE
Connect to Docker daemon on host through Unix socket.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,19 +15,14 @@ services:
       # Bind Docker binary from host machine so we can invoke Docker commands
       # from inside container
       - "/usr/local/bin/docker:/usr/local/bin/docker:ro"
-      # Bind Docker TLS certs from host machine so we can authenticate with the
-      # daemon on the host (DOCKER_HOST should be set to host's IP)
-      - "/etc/docker:/etc/docker:ro"
+      # Bind Docker socket on the host so we can connect to the daemon from
+      # within the container
+      - "/var/run/docker.sock:/var/run/docker.sock:rw"
       # Bind Docker volume on host for JupyterHub database and cookie secrets
       - "data:${DATA_VOLUME_CONTAINER}"
     ports:
       - "443:443"
     environment:
-      # Pass DOCKER_HOST to container to allow it to connect to daemon on host
-      DOCKER_HOST: ${DOCKER_HOST}
-      # Locations of TLS certificate and key needed to auth with daemon on host
-      DOCKER_TLS_CERT: "/etc/docker/server.pem"
-      DOCKER_TLS_KEY: "/etc/docker/server-key.pem"
       # All containers will join this network
       DOCKER_NETWORK_NAME: ${DOCKER_NETWORK_NAME}
       # JupyterHub will spawn this Notebook image for users

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -39,10 +39,6 @@ c.DockerSpawner.volumes = { '{username}': '/home/jovyan/work' }
 c.DockerSpawner.extra_create_kwargs.update({ 'volume_driver': 'local' })
 # Remove containers once they are stopped
 c.DockerSpawner.remove_containers = True
-# Specify paths to TLS certificate and key used to authenticate to Docker
-# daemon at DOCKER_HOST
-c.DockerSpawner.tls_cert = os.environ['DOCKER_TLS_CERT']
-c.DockerSpawner.tls_key = os.environ['DOCKER_TLS_KEY']
 # For debugging arguments passed to spawned containers
 c.DockerSpawner.debug = True
 


### PR DESCRIPTION
Mount the host Docker daemon's unix socket in the JHub container.  This allows DockerSpawner to communicate with the daemon over the socket instead of having to rely on setting DOCKER_HOST and connecting using TLS over public IP.

In short, for a single-machine deployment, it's simpler this way, especially when deploying from directly on the host (without using docker-machine remotely).

@minrk I saw you do this in a branch.  Makes sense.  The DOCKER_HOST/TLS route was a holdover from my original Docker Swarm deployment.
