### PR TITLE
[WIP] Upgrade example for JupyterHub 0.7

### DIFF
--- a/Dockerfile.jupyterhub
+++ b/Dockerfile.jupyterhub
@@ -1,10 +1,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyterhub/jupyterhub-onbuild:0.6.1
+FROM jupyterhub/jupyterhub-onbuild:0.7.0
 
 # Install dockerspawner and its dependencies
 RUN /opt/conda/bin/pip install \
-    jupyterhub==0.6.* \
     oauthenticator==0.4.* \
     dockerspawner==0.4.*
 


### PR DESCRIPTION
Removes the redundant pip install of JupyterHub. It's already in the base image.

Hold this PR until JupyterHub 0.7 is released and the images on DockerHub are updated and tagged.