### PR TITLE
Remove "make up" target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 include .env
 
 .DEFAULT_GOAL=build
@@ -43,7 +46,4 @@ notebook_image: pull
 build: check-files network volumes
 	docker-compose build
 
-up:
-	docker-compose up -d
-
-.PHONY: network volumes check-files pull notebook_image build up
+.PHONY: network volumes check-files pull notebook_image build


### PR DESCRIPTION
Using `make up` adds another level of indirection to bringing up JupyterHub, and in this case, it doesn't do the right thing, and may lead to confusion (see #26).  

Specifically, `make up` does not export the environment variables in the `.env` file.

We _could_ "fix" this by doing:

```
include .env
export
```

BUT `make` works differently than `docker-compose` in that `make` would honor the file content over the shell environment variables by default.  Users would have to explicitly tell `make` to use the shell variables over the `.env` file by passing the `-e` flag (see [here](https://www.gnu.org/software/make/manual/html_node/Environment.html#Environment)):

```
make -e up
```

Wait, wut?

My fix for this is to remove `make up` and just run `docker-compose up -d` as it says in the README. (This repo _is_ about using Docker after all).