### PR TITLE
Bump versions of hub dependencies, notebook image

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ DOCKER_MACHINE_NAME=jupyterhub
 DOCKER_NETWORK_NAME=jupyterhub-network
 
 # Single-user Jupyter Notebook server container image
-DOCKER_NOTEBOOK_IMAGE=jupyter/scipy-notebook:2d878db5cbff
+DOCKER_NOTEBOOK_IMAGE=jupyter/scipy-notebook:18e5563b7486
 
 # Notebook directory in the container.
 # This will be /home/jovyan/work if the default

--- a/Dockerfile.jupyterhub
+++ b/Dockerfile.jupyterhub
@@ -4,8 +4,8 @@ FROM jupyterhub/jupyterhub-onbuild:0.7.0
 
 # Install dockerspawner and its dependencies
 RUN /opt/conda/bin/pip install \
-    oauthenticator==0.4.* \
-    dockerspawner==0.4.*
+    oauthenticator==0.5.* \
+    dockerspawner==0.5.*
 
 # install docker on the jupyterhub container
 RUN wget https://get.docker.com -q -O /tmp/getdocker && \


### PR DESCRIPTION
Now that JupyterHub 0.7 is released, time to bump to the latest versions of dependencies.  

Also bump to much more recent version of default notebook image.