### PR TITLE
Add oauth.env target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ secrets/postgres.env:
 	@echo "Generating postgres password in $@"
 	@echo "POSTGRES_PASSWORD=$(shell openssl rand -hex 32)" > $@
 
+secrets/oauth.env:
+	@echo "Need oauth.env file in secrets with GitHub parameters"
+	@exit 1
+
 secrets/jupyterhub.crt:
 	@echo "Need an SSL certificate in secrets/jupyterhub.crt"
 	@exit 1

--- a/README.md
+++ b/README.md
@@ -118,20 +118,21 @@ Secret and OAuth callback url. You can do this by either:
 - setting the `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and
   `OAUTH_CALLBACK_URL` environment variables when you run the
   JupyterHub container, or
-- add them to the `.env` file in the root directory of this repository.
-  For example, update the following lines in the `.env` file:
+- add them to an `oauth.env` file in the `secrets` directory of this repository.
+  You may need to create both the `secrets` directory and the `oauth.env` file.
+  For example, add the following lines in the `oauth.env` file:
 
-  `.env` file
+  `oauth.env` file
   ```
   GITHUB_CLIENT_ID=<github_client_id>
   GITHUB_CLIENT_SECRET=<github_client_secret>
   OAUTH_CALLBACK_URL=https://<myhost.mydomain>/hub/oauth_callback
   ```
 
-  **Note:** The `.env` file is a special file that Docker Compose uses
+  **Note:** The `oauth.env` file is a special file that Docker Compose uses
   to lookup environment variables. If you choose to place the GitHub
   OAuth application settings in this file, you should make sure that the
-  file remains private (be careful to not commit the `.env` file with
+  file remains private (be careful to not commit the `oauth.env` file with
   these secrets to source control).
 
 


### PR DESCRIPTION
Since 6917060, docker compose relies on an oauth.env file to get
the OAuth parameters, so the Makefile is updated to handle here
this change. In addition, the README is updated.