### PR TITLE
Updated LetsEncrypt docker-compose to fix 'links' service extension. …

### DIFF
--- a/examples/letsencrypt/README.md
+++ b/examples/letsencrypt/README.md
@@ -64,5 +64,7 @@ configuration in this directory:
 ```
 export SECRETS_VOLUME=jupyterhub-secrets
 
-docker-compose -f examples/letsencrypt/docker-compose.yml up -d
+docker-compose -f docker-compose.yml -f examples/letsencrypt/docker-compose.yml up -d
 ```
+
+You may need to create empty crt and key files inside the secrets folder in order to successfully build the jupyterhub image.

--- a/examples/letsencrypt/docker-compose.yml
+++ b/examples/letsencrypt/docker-compose.yml
@@ -13,9 +13,6 @@ version: "2"
 
 services:
   hub:
-    extends: # hub service in repository root directory
-      file: ../../docker-compose.yml
-      service: hub
     volumes:
      - "secrets:/etc/letsencrypt"
     environment:

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -21,12 +21,17 @@ c.DockerSpawner.container_image = os.environ['DOCKER_NOTEBOOK_IMAGE']
 # using the DOCKER_SPAWN_CMD environment variable.
 spawn_cmd = os.environ.get('DOCKER_SPAWN_CMD', "start-singleuser.sh")
 c.DockerSpawner.extra_create_kwargs.update({ 'command': spawn_cmd })
+
+#NVIDIA Docker config
+c.DockerSpawner.read_only_volumes = {"nvidia_driver_384.59":"/usr/local/nvidia"}
+c.DockerSpawner.extra_host_config = { "devices":["/dev/nvidiactl","/dev/nvidia-uvm","/dev/nvidia0"] }
+
 # Connect containers to this Docker network
 network_name = os.environ['DOCKER_NETWORK_NAME']
 c.DockerSpawner.use_internal_ip = True
 c.DockerSpawner.network_name = network_name
 # Pass the network name as argument to spawned containers
-c.DockerSpawner.extra_host_config = { 'network_mode': network_name }
+c.DockerSpawner.extra_host_config.update({ 'network_mode': network_name })
 # Explicitly set notebook directory because we'll be mounting a host volume to
 # it.  Most jupyter/docker-stacks *-notebook images run the Notebook server as
 # user `jovyan`, and set the notebook directory to `/home/jovyan/work`.
@@ -36,7 +41,6 @@ c.DockerSpawner.notebook_dir = notebook_dir
 # Mount the real user's Docker volume on the host to the notebook user's
 # notebook directory in the container
 c.DockerSpawner.volumes = { 'jupyterhub-user-{username}': notebook_dir }
-c.DockerSpawner.extra_create_kwargs.update({ 'volume_driver': 'local' })
 # Remove containers once they are stopped
 c.DockerSpawner.remove_containers = True
 # For debugging arguments passed to spawned containers


### PR DESCRIPTION
I am using the Letsencrypt example to deploy the service with a valid SSL certificate. Following [these](https://github.com/jupyterhub/jupyterhub-deploy-docker/blob/master/examples/letsencrypt/README.md) instructions I was not able to start the container with the following error:
`ERROR: Cannot extend service 'hub' in /home/ml/jupyterhub-deploy-docker/docker-compose.yml: services with 'links' cannot be extended`. 

I've modified the letsecrypt specific docker-compose.yml according to  https://github.com/docker/compose/issues/1617 to allow service extension even with links. I have updated the README file accordingly.

I also noted that the jupyterhub Dockerfile requires .crt and .key files to be present in the secrets folder in order to build the image. So the user may need to create these empty files to avoid getting non-existent file errors. I thought about a nicer way to overcome this issue but this seemed to be the easiest one.