### PR TITLE
Modified Dockerfile to copy jupyterhub_config.py to the container.

### DIFF
--- a/Dockerfile.jupyterhub
+++ b/Dockerfile.jupyterhub
@@ -18,3 +18,4 @@ RUN chmod 700 /srv/jupyterhub/secrets && \
     chmod 600 /srv/jupyterhub/secrets/*
 
 COPY ./userlist /srv/jupyterhub/userlist
+COPY ./jupyterhub_config.py /srv/jupyterhub/


### PR DESCRIPTION
I was modifying the `jupyterhub_config.py` file in the project root, however the changes seemed to have no effect on the Jupyterhub service. I then realized that this file is not copied during the image building phase. So I modified the `Dockerfile.jupyterhub` to copy it to the proper location. I believe this was a mistake, but perhaps nobody needed to change the default values until now.