### PR TITLE
Updated LetsEncrypt docker-compose to fix 'links' service extension

### DIFF
--- a/examples/letsencrypt/README.md
+++ b/examples/letsencrypt/README.md
@@ -64,5 +64,7 @@ configuration in this directory:
 ```
 export SECRETS_VOLUME=jupyterhub-secrets
 
-docker-compose -f examples/letsencrypt/docker-compose.yml up -d
+docker-compose -f docker-compose.yml -f examples/letsencrypt/docker-compose.yml up -d
 ```
+
+You may need to create empty crt and key files inside the secrets folder in order to successfully build the jupyterhub image.

--- a/examples/letsencrypt/docker-compose.yml
+++ b/examples/letsencrypt/docker-compose.yml
@@ -13,9 +13,6 @@ version: "2"
 
 services:
   hub:
-    extends: # hub service in repository root directory
-      file: ../../docker-compose.yml
-      service: hub
     volumes:
      - "secrets:/etc/letsencrypt"
     environment:


### PR DESCRIPTION
I am using the Letsencrypt example to deploy the service with a valid SSL certificate. Following [these](https://github.com/jupyterhub/jupyterhub-deploy-docker/blob/master/examples/letsencrypt/README.md) instructions I was not able to start the container with the following error:
`ERROR: Cannot extend service 'hub' in /home/ml/jupyterhub-deploy-docker/docker-compose.yml: services with 'links' cannot be extended`. 

I've modified the letsecrypt specific docker-compose.yml according to  https://github.com/docker/compose/issues/1617 to allow service extension even with links. I have updated the README file accordingly.

I also noted that the jupyterhub Dockerfile requires .crt and .key files to be present in the secrets folder in order to build the image. So the user may need to create these empty files to avoid getting non-existent file errors. I thought about a nicer way to overcome this issue but this seemed to be the easiest one.