### PR TITLE
Change mountpoint of the PostgreSQL database

### DIFF
--- a/.env
+++ b/.env
@@ -39,7 +39,7 @@ DATA_VOLUME_CONTAINER=/data
 DB_VOLUME_HOST=jupyterhub-db-data
 
 # Postgres volume container mount point
-DB_VOLUME_CONTAINER=/var/lib/postgresql/data/jupyterhub
+DB_VOLUME_CONTAINER=/var/lib/postgresql/data
 
 # The name of the postgres database containing JupyterHub state
 POSTGRES_DB=jupyterhub


### PR DESCRIPTION
Make it match the VOLUME declaration in the official postgres image Dockerfile.

Otherwise docker-compose creates an unamed volume mounted at /var/lib/postgresql/data along with the jupyterhub-db-data volume.

The hub will continue working as before when you restart with the updated DB_VOLUME_CONTAINER env variable and you will be able to remove the unnecessary volume that was created since it won't be attached any more.