### PR TITLE
volume_driver is no longer a keyword argument to create_container()

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -36,7 +36,8 @@ c.DockerSpawner.notebook_dir = notebook_dir
 # Mount the real user's Docker volume on the host to the notebook user's
 # notebook directory in the container
 c.DockerSpawner.volumes = { 'jupyterhub-user-{username}': notebook_dir }
-c.DockerSpawner.extra_create_kwargs.update({ 'volume_driver': 'local' })
+# volume_driver is no longer a keyword argument to create_container()
+# c.DockerSpawner.extra_create_kwargs.update({ 'volume_driver': 'local' })
 # Remove containers once they are stopped
 c.DockerSpawner.remove_containers = True
 # For debugging arguments passed to spawned containers


### PR DESCRIPTION
Probably on account of https://github.com/docker/docker-py/issues/1543

Not sure if this repository is meant to remain up to date, but I get 500 errors when using this setup on a fresh install.

~~~
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.5/site-packages/tornado/web.py", line 1511, in _execute
        result = yield result
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub/handlers/base.py", line 744, in get
        yield self.spawn_single_user(current_user)
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub/handlers/base.py", line 474, in spawn_single_user
        yield gen.with_timeout(timedelta(seconds=self.slow_spawn_timeout), finish_spawn_future)
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub/handlers/base.py", line 444, in finish_user_spawn
        yield spawn_future
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub/user.py", line 439, in spawn
        raise e
      File "/opt/conda/lib/python3.5/site-packages/jupyterhub/user.py", line 378, in spawn
        ip_port = yield gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)
      File "/opt/conda/lib/python3.5/site-packages/dockerspawner/dockerspawner.py", line 536, in start
        resp = yield self.docker('create_container', **create_kwargs)
      File "/opt/conda/lib/python3.5/concurrent/futures/_base.py", line 398, in result
        return self.__get_result()
      File "/opt/conda/lib/python3.5/concurrent/futures/_base.py", line 357, in __get_result
        raise self._exception
      File "/opt/conda/lib/python3.5/concurrent/futures/thread.py", line 55, in run
        result = self.fn(*self.args, **self.kwargs)
      File "/opt/conda/lib/python3.5/site-packages/dockerspawner/dockerspawner.py", line 409, in _docker
        return m(*args, **kwargs)
    TypeError: create_container() got an unexpected keyword argument 'volume_driver'
~~~