### PR TITLE
in case of newline at the end of userlist file

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -78,7 +78,9 @@ with open(os.path.join(pwd, 'userlist')) as f:
         if not line:
             continue
         parts = line.split()
-        name = parts[0]
-        whitelist.add(name)
-        if len(parts) > 1 and parts[1] == 'admin':
-            admin.add(name)
+        # in case of newline at the end of userlist file
+        if len(parts) >= 1:
+            name = parts[0]
+            whitelist.add(name)
+            if len(parts) > 1 and parts[1] == 'admin':
+                admin.add(name)


### PR DESCRIPTION
It's a habit for some developers to append a newline at the end of the file, but line 82 did not take this into consideration. And the consequence is that JupyterHub would keep restarting.