### PR TITLE
COPY jupyterhub_config.py to Dockerfile.jupyterhub image

### DIFF
--- a/Dockerfile.jupyterhub
+++ b/Dockerfile.jupyterhub
@@ -19,3 +19,4 @@ RUN chmod 700 /srv/jupyterhub/secrets && \
     chmod 600 /srv/jupyterhub/secrets/*
 
 COPY ./userlist /srv/jupyterhub/userlist
+COPY ./jupyterhub_config.py /srv/jupyterhub/jupyterhub_config.py

--- a/Dockerfile.jupyterhub
+++ b/Dockerfile.jupyterhub
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 ARG JUPYTERHUB_VERSION
-FROM jupyterhub/jupyterhub-onbuild:$JUPYTERHUB_VERSION
+FROM jupyterhub/jupyterhub:$JUPYTERHUB_VERSION
 
 # Install dockerspawner, oauth, postgres
 RUN /opt/conda/bin/conda install -yq psycopg2=2.7 && \


### PR DESCRIPTION
Shouldn't `jupyterhub_config.py` be copied to the image so it reflects changes made? I was editing my `jupyterhub_config.py` file and noticed that changes were not reflecting. 