### PR TITLE
Fix to build fail

### DIFF
--- a/Dockerfile.jupyterhub
+++ b/Dockerfile.jupyterhub
@@ -4,7 +4,7 @@ ARG JUPYTERHUB_VERSION
 FROM jupyterhub/jupyterhub-onbuild:$JUPYTERHUB_VERSION
 
 # Install dockerspawner, oauth, postgres
-RUN /opt/conda/bin/conda install -yq psycopg2=2.7 && \
+RUN /opt/conda/bin/conda install -yq psycopg2=2.7 python=3.6 && \
     /opt/conda/bin/conda clean -tipsy && \
     /opt/conda/bin/pip install --no-cache-dir \
         oauthenticator==0.8.* \


### PR DESCRIPTION
I built fail.
I found that when conda install psycopg2, python is upgraded 3.6 to 3.7.
This is caused to fail conda clean line and also caused to upgrade jupyter to 1.0.0.
So I add `python=3.6` for fixed minor version.