### PR TITLE
Copy config explicitly

### DIFF
--- a/basic-example/Dockerfile.jupyterhub
+++ b/basic-example/Dockerfile.jupyterhub
@@ -8,4 +8,5 @@ RUN python3 -m pip install --no-cache-dir \
         dockerspawner==12.* \
         jupyterhub-nativeauthenticator==1.*
 
+COPY ./jupyterhub_config.py /srv/jupyterhub/jupyterhub_config.py
 CMD ["jupyterhub", "-f", "/srv/jupyterhub/jupyterhub_config.py"]


### PR DESCRIPTION
Close: https://github.com/jupyterhub/jupyterhub-deploy-docker/pull/88

I think it's better to be explicit, because ONBUILD instructions are not obvious and you don't know about them until you start diving deep into parent docker image.