### PR TITLE
allow all signed-up admin users to login by default

### DIFF
--- a/basic-example/jupyterhub_config.py
+++ b/basic-example/jupyterhub_config.py
@@ -46,6 +46,9 @@ c.JupyterHub.hub_port = 8080
 c.JupyterHub.cookie_secret_file = "/data/jupyterhub_cookie_secret"
 c.JupyterHub.db_url = "sqlite:////data/jupyterhub.sqlite"
 
+# Allow all signed-up users to login
+c.Authenticator.allow_all = True
+
 # Authenticate users with Native Authenticator
 c.JupyterHub.authenticator_class = "nativeauthenticator.NativeAuthenticator"
 


### PR DESCRIPTION
Admin user can't login after signed up without `c.Authenticator.allow_all = True` in config file. This could be confused.